### PR TITLE
os_auth needs to be an empty dict

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,7 +1,7 @@
 ---
 # defaults file for openstack_instance
 
-os_auth: []
+os_auth: {}
 os_instance_name: "os-instance-{{ 9999 | random | to_uuid }}"
 os_instance_image: cirros
 os_instance_flavor: m1.tiny


### PR DESCRIPTION
otherwise, if using ENV instead of cloud.yaml to define connection parameters (username,password etc.), Ansible will through an error if os_auth is an empty list. See also https://docs.ansible.com/ansible/latest/modules/os_server_module.html that auth is expected to be a dict.